### PR TITLE
Fix platform compatibility / building to unsupported platforms

### DIFF
--- a/Packages/jp.keijiro.lasp/Runtime/Lasp.Runtime.asmdef
+++ b/Packages/jp.keijiro.lasp/Runtime/Lasp.Runtime.asmdef
@@ -5,11 +5,17 @@
         "GUID:2665a8d13d1b3f18800f46e256720795",
         "GUID:d8b63aba1907145bea998dd612889d6b"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor",
+        "macOSStandalone",
+        "WindowsStandalone64"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": true,
-    "overrideReferences": false,
-    "precompiledReferences": [],
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "System.Memory.dll"
+    ],
     "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [],


### PR DESCRIPTION
SoundIO is only Editor, Mac, Win64, so LASP currently throws compilation errors when trying to build to those platforms.
Thus, this PR fixes the LASP asmdef to only be valid for the same platforms.

Follow-up question: do you have any plans/do you know if there are plans to have soundio support more platforms, e.g. Android/iOS/WebGL?